### PR TITLE
Fix build script

### DIFF
--- a/lib/build.sh
+++ b/lib/build.sh
@@ -33,7 +33,7 @@ install_or_reuse_node_modules() {
   local build_dir=$1
 
   if detect_package_lock $build_dir ; then
-    echo "---> Restoring node modules from ./package-lock.json"
+    echo "---> Installing node modules from ./package-lock.json"
     if use_npm_ci ; then
       npm ci
     else


### PR DESCRIPTION
I had pushed up some code in #3  that I assumed worked, but it did not, so these are the fixes.

### Issue
the `jq` library from the nodejs-engine buildpack was not being imported into the nodejs-npm buildpack, so the build steps were throwing errors because the library was not found.

There seemed to be an issue when adding $layers_dir/bin to PATH... and it wasn't being set in the subsequent buildpack. It's like that layer was skipped over entirely when booting npm buildpack, even though it is correctly installed and set in PATH in the engine buildpack (where it's originally installed).

### Fix
there is an accompanying PR coming that changes the name of the "bin" layer from the engine buildpack.

---

After this, jq needs different notation for parsing package.json when keys uses hyphens.

The fix is to do something like `.scripts[\"heroku-build\"]` when querying.