### PR TITLE
Fix error on missing package-lock.json

### DIFF
--- a/CHAGELOG.md
+++ b/CHAGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## master
+
+## 0.0.2 (2019-10-11)
+### Fixed
+- Fix broken builds when a `package-lock.json` is missing ([#9](https://github.com/heroku/nodejs-npm-buildpack/pull/9))

--- a/buildpack.toml
+++ b/buildpack.toml
@@ -2,7 +2,7 @@ api = "0.2"
 
 [buildpack]
 id = "heroku/nodejs-npm-buildpack"
-version = "0.0.1"
+version = "0.0.2"
 name = "NPM Buildpack"
 
 [[stacks]]

--- a/lib/build.sh
+++ b/lib/build.sh
@@ -58,14 +58,21 @@ install_or_reuse_node_modules() {
   local build_dir=$1
   local layer_dir=$2
   local local_lock_checksum
+  local cached_lock_checksum
+
+  if ! detect_package_lock "$build_dir"; then
+    install_modules "$build_dir" "$layer_dir"
+    return 0
+  fi
+
+  touch "$layer_dir.toml"
 
   local_lock_checksum=$(sha256sum "$build_dir/package-lock.json" | cut -d " " -f 1)
+  cached_lock_checksum=$(yj -t < "$layer_dir.toml" | jq -r ".metadata.package_lock_checksum")
 
   mkdir -p "${layer_dir}"
 
-  if [[ -f "$build_dir/package-lock.json"
-    && -f "$layer_dir.toml"
-    && $local_lock_checksum == $(yj -t < "$layer_dir.toml" | jq -r ".metadata.package_lock_checksum") ]] ; then
+  if [[ -f "$layer_dir.toml" && "$local_lock_checksum" == "$cached_lock_checksum" ]] ; then
       echo "---> Reusing node modules"
       cp -r "$layer_dir" "$build_dir/node_modules"
   else

--- a/lib/build.sh
+++ b/lib/build.sh
@@ -66,13 +66,12 @@ install_or_reuse_node_modules() {
   fi
 
   touch "$layer_dir.toml"
-
-  local_lock_checksum=$(sha256sum "$build_dir/package-lock.json" | cut -d " " -f 1)
-  cached_lock_checksum=$(yj -t < "$layer_dir.toml" | jq -r ".metadata.package_lock_checksum")
-
   mkdir -p "${layer_dir}"
 
-  if [[ -f "$layer_dir.toml" && "$local_lock_checksum" == "$cached_lock_checksum" ]] ; then
+  local_lock_checksum=$(sha256sum "$build_dir/package-lock.json" | cut -d " " -f 1)
+  cached_lock_checksum=$(yj -t < "${layer_dir}.toml" | jq -r ".metadata.package_lock_checksum")
+
+  if [[ "$local_lock_checksum" == "$cached_lock_checksum" ]] ; then
       echo "---> Reusing node modules"
       cp -r "$layer_dir" "$build_dir/node_modules"
   else


### PR DESCRIPTION
When a project doesn't have a package-lock.json, the buildpack errors. What we want for lock-less projects is to forgo the caching and download the node modules each time, since this would be the expected behavior from a lock-less file.

## Includes
- install modules without looking at cache if there is no package-lock.json
- create empty node_modules.toml if not present
- remove check for package-lock.json before checking if to use the cache
- CHANGELOG