### PR TITLE
Remove -buildpack from buildpack id

### DIFF
--- a/buildpack.toml
+++ b/buildpack.toml
@@ -1,7 +1,7 @@
 api = "0.2"
 
 [buildpack]
-id = "heroku/nodejs-npm-buildpack"
+id = "heroku/nodejs-npm"
 version = "0.1.2"
 name = "NPM Buildpack"
 


### PR DESCRIPTION
The "buildpack" is implied in all contexts (i.e. we don't publish this to a generic registry like NPM).