### PR TITLE
Bump version for release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.1.3 (2020-01-28)
+###
+- fix: remove `-buildpack` from buildpack id ([#16](https://github.com/heroku/nodejs-npm-buildpack/pull/16))
+- feat: support running on `io.buildpacks.stacks.bionic` stack ([#17](https://github.com/heroku/nodejs-npm-buildpack/pull/17))
+
 ## 0.1.2 (2019-11-01)
 ###
 - feat: support build time environment variables ([#14](https://github.com/heroku/nodejs-npm-buildpack/pull/14))

--- a/buildpack.toml
+++ b/buildpack.toml
@@ -2,7 +2,7 @@ api = "0.2"
 
 [buildpack]
 id = "heroku/nodejs-npm"
-version = "0.1.2"
+version = "0.1.3"
 name = "NPM Buildpack"
 
 [[stacks]]


### PR DESCRIPTION
Cut a new release with the buildpack id change and the updated supported stacks so we can cut a new builder release.