### PR TITLE
fix use_npm_ci command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 0.1.4 (2020-01-28)
+## 0.1.4 (2020-02-14)
 ### Fixed
 - fix: use_npm_ci expression return value id ([#22](https://github.com/heroku/nodejs-npm-buildpack/pull/23))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.1.4 (2020-01-28)
+### Fixed
+- fix: use_npm_ci expression return value id ([#22](https://github.com/heroku/nodejs-npm-buildpack/pull/23))
+
 ## 0.1.3 (2020-01-28)
 ###
 - fix: remove `-buildpack` from buildpack id ([#16](https://github.com/heroku/nodejs-npm-buildpack/pull/16))

--- a/lib/build.sh
+++ b/lib/build.sh
@@ -25,7 +25,7 @@ use_npm_ci() {
   major=$(echo "$npm_version" | cut -f1 -d ".")
   minor=$(echo "$npm_version" | cut -f2 -d ".")
 
-  [[ "$major" -gt "5" || ("$major" == "5" || "$minor" -gt "6") ]]
+  [[ "$major" -gt "5" || ("$major" == "5" && "$minor" -gt "6") ]]
 }
 
 run_prebuild() {


### PR DESCRIPTION
# Description

This should fix use_npm_ci() to correctly use npm install with npm 5.6.

Fixes # (issue) https://github.com/heroku/nodejs-npm-buildpack/issues/22

# Checklist:

- [ ] Run these changes with `pack`
- [x] Make updates to `CHANGELOG.md`
