### PR TITLE
add docs to README for permission denied issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## master
+- docs: add docs around `Permission denied` issues ([#28](https://github.com/heroku/nodejs-npm-buildpack/pull/28))
 
 ## 0.1.4 (2020-02-19)
 ### Added

--- a/README.md
+++ b/README.md
@@ -93,6 +93,18 @@ Now you can use the builder image instead of chaining the buildpacks.
 pack build TEST_IMAGE_NAME --path ../TEST_REPO_PATH --builder nodejs
 ```
 
+### Common Issues
+
+#### `jq: Permission denied` on a build
+
+This issue may happen if a binary that is installed is not executable. This may happen on a Linux machine or while using a private network, such as a VPN, when using a local buildpack tool. If using `sfdx evergreen` or `pack`, pass in `--network host` to the command.
+
+An example of this command running from the source code directory with a local builder image called `nodejs` would look like this:
+
+```sh
+pack build TEST_IMAGE_NAME --builder nodejs --network host
+```
+
 ## Contributing
 
 1. Open a pull request.

--- a/README.md
+++ b/README.md
@@ -105,6 +105,12 @@ An example of this command running from the source code directory with a local b
 pack build TEST_IMAGE_NAME --builder nodejs --network host
 ```
 
+If building a function with `sfdx`, a command looks like this:
+
+```sh
+sfdx evergreen:functions:build image-repo/myfunction:dev --network host
+```
+
 ## Contributing
 
 1. Open a pull request.


### PR DESCRIPTION
# Description

Adds some documentation in case anyone gets intermittent failures that seem to flake depending on the network connection. 

Fixes https://github.com/heroku/nodejs-npm-buildpack/issues/15

cc @elbandito @cwallsfdc

# Checklist:

~~- [ ] Run these changes with `pack`~~
- [x] Make updates to `CHANGELOG.md`
