### PR TITLE
add NODE_ENV for opting out of pruning devdependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## master
 ### Added
 - Prune devdependencies ([#32](https://github.com/heroku/nodejs-npm-buildpack/pull/32))
+- Opt out of pruning devdependencies if NODE_ENV is not production ([#33](https://github.com/heroku/nodejs-npm-buildpack/pull/33))
 
 ## 0.2.0 (2020-05-19)
 ### Added

--- a/lib/build.sh
+++ b/lib/build.sh
@@ -171,10 +171,8 @@ prune_devdependencies() {
 
   if [ "$NODE_ENV" != "production" ]; then
     log_info "Skip pruning because NODE_ENV is not 'production'."
-    echo "pruning skipped"
   else
     npm prune --userconfig "$build_dir/.npmrc" 2>&1
     log_info "Successfully pruned devdependencies!"
-    echo "pruning successful"
   fi
 }

--- a/lib/build.sh
+++ b/lib/build.sh
@@ -169,6 +169,12 @@ prune_devdependencies() {
 
   npm_version=$(npm -v)
 
-  npm prune --userconfig "$build_dir/.npmrc" 2>&1
-  log_info "Successfully pruned devdependencies!"
+  if [ "$NODE_ENV" != "production" ]; then
+    log_info "Skip pruning because NODE_ENV is not 'production'."
+    echo "pruning skipped"
+  else
+    npm prune --userconfig "$build_dir/.npmrc" 2>&1
+    log_info "Successfully pruned devdependencies!"
+    echo "pruning successful"
+  fi
 }

--- a/shpec/build_shpec.sh
+++ b/shpec/build_shpec.sh
@@ -51,9 +51,34 @@ use_npm() {
 
 describe "lib/build.sh"
   install_tools
-  stub_command "log_info"
 
   CURRENT_PATH=$PATH
+
+  describe "prune_devdependencies"
+    project_dir=$(create_temp_project_dir)
+    use_npm 6
+
+    it "skips pruning when NODE_ENV is not 'production'"
+      export NODE_ENV=not-production
+      result=$(prune_devdependencies "$project_dir")
+      assert equal "$result" "---> Skip pruning because NODE_ENV is not 'production'."
+    end
+
+    it "successfully prunes when NODE_ENV is 'production'"
+      export NODE_ENV=production
+      result=$(prune_devdependencies "$project_dir")
+      assert equal "$result" "---> Successfully pruned devdependencies!"
+    end
+
+    it "successfully prunes devdependencies"
+      prune_devdependencies "$project_dir"
+      assert equal $? 0
+    end
+
+    rm_temp_dirs "$project_dir"
+  end
+
+  stub_command "log_info"
 
   describe "detect_package_lock"
     project_dir=$(create_temp_project_dir)
@@ -251,30 +276,6 @@ describe "lib/build.sh"
     rm_temp_dirs "$project_dir" "$layers_dir"
   end
 
-  describe "prune_devdependencies"
-    project_dir=$(create_temp_project_dir)
-    use_npm 6
-
-    it "skips pruning when NODE_ENV is not 'production'"
-      export NODE_ENV=not-production
-      result=$(prune_devdependencies "$project_dir")
-      assert equal "$result" "pruning skipped"
-    end
-
-    it "successfully prunes when NODE_ENV is 'production'"
-      export NODE_ENV=production
-      result=$(prune_devdependencies "$project_dir")
-      assert equal "$result" "pruning successful"
-    end
-
-    it "successfully prunes devdependencies"
-      prune_devdependencies "$project_dir"
-      assert equal $? 0
-    end
-
-    rm_temp_dirs "$project_dir"
-  end
-
-  rm_tools_and_mocks
   unstub_command "log_info"
+  rm_tools_and_mocks
 end

--- a/shpec/build_shpec.sh
+++ b/shpec/build_shpec.sh
@@ -255,10 +255,24 @@ describe "lib/build.sh"
     project_dir=$(create_temp_project_dir)
     use_npm 6
 
+    it "skips pruning when NODE_ENV is not 'production'"
+      export NODE_ENV=not-production
+      result=$(prune_devdependencies "$project_dir")
+      assert equal "$result" "pruning skipped"
+    end
+
+    it "successfully prunes when NODE_ENV is 'production'"
+      export NODE_ENV=production
+      result=$(prune_devdependencies "$project_dir")
+      assert equal "$result" "pruning successful"
+    end
+
     it "successfully prunes devdependencies"
       prune_devdependencies "$project_dir"
       assert equal $? 0
     end
+
+    rm_temp_dirs "$project_dir"
   end
 
   rm_tools_and_mocks


### PR DESCRIPTION
# Description

If NODE_ENV is not set to production (ex: test or staging) then we will install devDependencies and skip pruning

# Checklist:

- [x] Run these changes with `pack`
- [x] Make updates to `CHANGELOG.md`
