### PR TITLE
warn if node modules are checked into git

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## master
 ### Added
 - Prune devdependencies ([#32](https://github.com/heroku/nodejs-npm-buildpack/pull/32))
+- Warn when node modules are checked into git ([#34](https://github.com/heroku/nodejs-npm-buildpack/pull/34))
 
 ## 0.2.0 (2020-05-19)
 ### Added

--- a/bin/build
+++ b/bin/build
@@ -17,6 +17,8 @@ export_env "$platform_dir/env" "" ""
 export PATH=$layers_dir/npm/bin:$PATH
 install_or_reuse_npm "$build_dir" "$layers_dir/npm"
 
+warn_prebuilt_modules "$build_dir"
+
 run_prebuild "$build_dir"
 
 install_or_reuse_node_modules "$build_dir" "$layers_dir/node_modules"

--- a/lib/build.sh
+++ b/lib/build.sh
@@ -176,6 +176,6 @@ prune_devdependencies() {
 warn_prebuilt_modules() {
   local build_dir=$1
   if [ -e "$build_dir/node_modules" ]; then
-    log_info "node_modules checked into source control" "https://blog.heroku.com/node-habits-2016#9-only-git-the-important-bits"
+    log_info "node_modules checked into source control" "https://devcenter.heroku.com/articles/node-best-practices#only-git-the-important-bits"
   fi
 }

--- a/lib/build.sh
+++ b/lib/build.sh
@@ -172,3 +172,10 @@ prune_devdependencies() {
   npm prune --userconfig "$build_dir/.npmrc" 2>&1
   log_info "Successfully pruned devdependencies!"
 }
+
+warn_prebuilt_modules() {
+  local build_dir=$1
+  if [ -e "$build_dir/node_modules" ]; then
+    log_info "node_modules checked into source control" "https://blog.heroku.com/node-habits-2016#9-only-git-the-important-bits"
+  fi
+}

--- a/shpec/build_shpec.sh
+++ b/shpec/build_shpec.sh
@@ -261,6 +261,18 @@ describe "lib/build.sh"
     end
   end
 
+  describe "warn_prebuilt_modules"
+    project_dir=$(create_temp_project_dir)
+
+    it "warns when node modules are checked into git"
+      mkdir -p "$project_dir/node_modules"
+      warn_prebuilt_modules "$project_dir"
+      assert equal $? 0
+    end
+    
+    rm_temp_dirs "$project_dir"
+  end
+
   rm_tools_and_mocks
   unstub_command "log_info"
 end


### PR DESCRIPTION
# Description

The app’s node_modules directory is generated at build time from the dependencies listed in package.json and the lockfile. Therefore, node_modules shouldn’t be checked into git. The user will receive a warning to encourage not doing so.

# Checklist:

- [x] Run these changes with `pack`
- [x] Make updates to `CHANGELOG.md`
