### PR TITLE
add circle config file and unit tests for each stack

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,67 @@
+version: 2.1
+orbs:
+  shellcheck: circleci/shellcheck@1.3.16
+  pack: buildpacks/pack@0.1.4
+jobs:
+  integration-test-nodejs-buildpacks:
+    machine: true
+    steps:
+      - pack/install-pack
+      - checkout
+      - run:
+          name: "Download project code"
+          command: git clone git@github.com:danielleadams/typescript-getting-started.git
+      - run:
+          name: "Set pack builder"
+          command: pack set-default-builder heroku/buildpacks:18
+      - run:
+          name: "Build OCI image with NPM and TypeScript buildpacks"
+          command:
+            pack build circle-build-1
+              --buildpack .
+              --buildpack heroku/nodejs-npm
+              --buildpack heroku/nodejs-typescript
+              --path ./typescript-getting-started
+      - run:
+          name: "Test image"
+          command: docker run circle-build-1 "node -v"
+  unit-test-heroku-stack:
+    parameters:
+      stack:
+        type: "string"
+        default: "heroku-20"
+    docker:
+      - image: "danielleadams/shpec-<<parameters.stack>>:latest"
+    steps:
+      - checkout
+      - setup_remote_docker:
+          docker_layer_caching: true
+      - run:
+          name: Shpec unit tests on <<parameters.stack>>
+          command: make unit-test
+  unit-test-binary:
+    docker:
+      - image: circleci/golang:1.14
+    steps:
+      - checkout
+      - setup_remote_docker:
+          docker_layer_caching: true
+      - run:
+          name: Run unit tests for Go
+          command: go test ./... -tags=integration
+workflows:
+  version: 2
+  run-tests:
+    jobs:
+      - unit-test-heroku-stack:
+          name: "Unit tests for heroku-20"
+          stack: "heroku-20"
+      - unit-test-heroku-stack:
+          name: "Unit tests for heroku-18"
+          stack: "heroku-18"
+      - unit-test-heroku-stack:
+          name: "Unit tests for heroku-16"
+          stack: "heroku-16"
+      - unit-test-binary:
+          name: "Unit tests for Go binaries"
+      - shellcheck/check

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,8 +18,8 @@ jobs:
           name: "Build OCI image with NPM and TypeScript buildpacks"
           command:
             pack build circle-build-1
+              --buildpack heroku/nodejs-engine
               --buildpack .
-              --buildpack heroku/nodejs-npm
               --buildpack heroku/nodejs-typescript
               --path ./typescript-getting-started
       - run:
@@ -53,3 +53,5 @@ workflows:
           name: "Unit tests for heroku-16"
           stack: "heroku-16"
       - shellcheck/check
+      - integration-test-nodejs-buildpacks:
+          name: "Integration tests with Heroku Node.js buildpacks"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,16 +39,6 @@ jobs:
       - run:
           name: Shpec unit tests on <<parameters.stack>>
           command: make unit-test
-  unit-test-binary:
-    docker:
-      - image: circleci/golang:1.14
-    steps:
-      - checkout
-      - setup_remote_docker:
-          docker_layer_caching: true
-      - run:
-          name: Run unit tests for Go
-          command: go test ./... -tags=integration
 workflows:
   version: 2
   run-tests:
@@ -62,6 +52,4 @@ workflows:
       - unit-test-heroku-stack:
           name: "Unit tests for heroku-16"
           stack: "heroku-16"
-      - unit-test-binary:
-          name: "Unit tests for Go binaries"
       - shellcheck/check

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## main
-- Move testing to CirleCI ([#37](https://github.com/heroku/nodejs-npm-buildpack/pull/37))
+- Move integration testing to CirleCI ([#37](https://github.com/heroku/nodejs-npm-buildpack/pull/37))
 
 ### Added
 - Prune devdependencies ([#32](https://github.com/heroku/nodejs-npm-buildpack/pull/32))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## main
+- Move testing to CirleCI ([#37](https://github.com/heroku/nodejs-npm-buildpack/pull/37))
+
 ### Added
 - Prune devdependencies ([#32](https://github.com/heroku/nodejs-npm-buildpack/pull/32))
 - Opt out of pruning devdependencies if NODE_ENV is not production ([#33](https://github.com/heroku/nodejs-npm-buildpack/pull/33))

--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,15 @@ test:
 	make shellcheck
 	make docker-unit-test
 
+unit-test-heroku-20:
+	@docker run -v $(PWD):/project danielleadams/shpec:latest
+
+unit-test-heroku-18:
+	@docker run -v $(PWD):/project danielleadams/shpec-heroku-18:latest
+
+unit-test-heroku-16:
+	@docker run -v $(PWD):/project danielleadams/shpec-heroku-16:latest
+
 docker-unit-test:
 	@docker run -v $(PWD):/project danielleadams/shpec:latest
 


### PR DESCRIPTION
# Description

This is to move testing to CircleCI and add separation of Heroku stacks. More work will need to be done, but this is the first PR to start adding more automation to buildpack testing and test integrations between buildpacks.

# Checklist:

- [x] Run these changes with `pack`
- [x] Make updates to `CHANGELOG.md`
