### PR TITLE
update pack --build-config flag to --config.

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ For local development, you'll want the file to look like this:
 Create the builder with `pack`:
 
 ```sh
-pack create-builder nodejs --builder-config ../heroku-nodejs-builder/builder.toml
+pack create-builder nodejs --config ../heroku-nodejs-builder/builder.toml
 ```
 
 Now you can use the builder image instead of chaining the buildpacks.


### PR DESCRIPTION
# Description

`pack` seems to have changed the flag from `--build-config` to `--config` at some point.

# Checklist:

- [x] Run these changes with `pack`
- [ ] Make updates to `CHANGELOG.md`
  - Not sure if ^ is needed for such a minor change(?)
