### PR TITLE
[#43] Ensure $layer_dir exists before installing npm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## main
+- Ensure prefix directory exists ([#42](https://github.com/heroku/nodejs-npm-buildpack/pull/44))
 
 ## 0.4.0 (2020-11-11)
 ### Added

--- a/lib/build.sh
+++ b/lib/build.sh
@@ -58,7 +58,7 @@ install_or_reuse_npm() {
       log_info "Using npm v${npm_version} from package.json"
     else
       log_info "Installing npm v${engine_npm} from package.json"
-      mkdir -p $(npm root -g --prefix "$layer_dir")
+      mkdir -p "$(npm root -g --prefix "$layer_dir")"
       npm install -g "npm@${engine_npm}" --prefix "$layer_dir" --quiet
 
       cat << TOML > "${layer_dir}.toml"

--- a/lib/build.sh
+++ b/lib/build.sh
@@ -58,6 +58,7 @@ install_or_reuse_npm() {
       log_info "Using npm v${npm_version} from package.json"
     else
       log_info "Installing npm v${engine_npm} from package.json"
+      mkdir -p $(npm root -g --prefix "$layer_dir")
       npm install -g "npm@${engine_npm}" --prefix "$layer_dir" --quiet
 
       cat << TOML > "${layer_dir}.toml"

--- a/mocks/npm/v6/bin/npm
+++ b/mocks/npm/v6/bin/npm
@@ -17,6 +17,13 @@ elif [[ "$1" == "install" ]]; then
     if [[ "$2" != "--no-package-lock" ]]; then
       touch package-lock.json
     fi
+  else
+    if [[ "$4" == "--prefix" ]]; then
+      if [[ ! -d "$(npm root -g --prefix "$5")" ]]; then
+        echo "npm prefix directory doesn't exist!"
+        exit 1
+      fi
+    fi
   fi
 elif [[ "$1" == "ci" ]]; then
   mkdir -p node_modules
@@ -25,5 +32,11 @@ elif [[ "$1" == "run" ]]; then
     mkdir -p heroku-postbuild
   elif [[ "$2" == "build" ]]; then
     mkdir -p build
+  fi
+elif [[ "$1" == "root" ]]; then
+  if [[ "$2" == "-g" ]]; then
+    if [[ "$3" == "--prefix" ]]; then
+      echo "$4" "/lib/node_modules"
+    fi
   fi
 fi

--- a/mocks/npm/v6/bin/npm
+++ b/mocks/npm/v6/bin/npm
@@ -36,7 +36,7 @@ elif [[ "$1" == "run" ]]; then
 elif [[ "$1" == "root" ]]; then
   if [[ "$2" == "-g" ]]; then
     if [[ "$3" == "--prefix" ]]; then
-      echo "$4" "/lib/node_modules"
+      echo "$4""/lib/node_modules"
     fi
   fi
 fi

--- a/shpec/build_shpec.sh
+++ b/shpec/build_shpec.sh
@@ -155,6 +155,7 @@ describe "lib/build.sh"
         it "uses the version installed with Node"
           install_or_reuse_npm "$project_dir" "$layers_dir/npm"
 
+          assert file_absent "$(npm root -g --prefix "$layers_dir/npm")"
           assert file_absent "$layers_dir/npm.toml"
         end
       end
@@ -165,6 +166,7 @@ describe "lib/build.sh"
         it "uses the version installed with Node"
           install_or_reuse_npm "$project_dir" "$layers_dir/npm"
 
+          assert file_absent "$(npm root -g --prefix "$layers_dir/npm")"
           assert file_absent "$layers_dir/npm.toml"
         end
       end
@@ -175,6 +177,7 @@ describe "lib/build.sh"
         it "installs the engine version of npm"
           install_or_reuse_npm "$project_dir" "$layers_dir/npm"
 
+          assert file_present "$(npm root -g --prefix "$layers_dir/npm")"
           assert file_present "$layers_dir/npm.toml"
         end
       end


### PR DESCRIPTION
# Description
When building with a `package.json` that specified an `npm` version, this buildpack was failing with `ENOENT: no such file or directory, lstat '/layers/heroku_nodejs-npm/npm'` (using `heroku/buildpacks:18` builder).

Seems that `npm` install with `--prefix` option may not create the required directories if they don't exist.

This pr ensures the `$layer_dir` directory is present when installing the specified `npm` version.

Fixes #42 

# Checklist:

- [x] Run these changes with `pack`
- [x] Make updates to `CHANGELOG.md`
