### PR TITLE
check for web process when image is built

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,7 +28,8 @@ jobs:
               --path ./typescript-getting-started
       - run:
           name: "Test image"
-          command: docker run circle-build-1 "node -v"
+          command: |
+            if [[ $(docker run --entrypoint "/bin/bash" circle-build-1 -c "ls /cnb/process | grep web") != "web" ]]; then { echo "Must have web process created"; exit 1; }; fi
   unit-test-heroku-stack:
     parameters:
       stack:


### PR DESCRIPTION
# Description

Based on https://github.com/heroku/nodejs-engine-buildpack/pull/64. To handle adding an entry point and looking for CNB process created.
